### PR TITLE
One more fix for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
fetch-depth needs to be 0 in order to get other branches, and in this case that includes the pages branch.
Otherwise the action fails if the docs were updated with some other call to `mkdocs gh-deploy`