### PR TITLE
Remove relax step from PHENIO

### DIFF
--- a/src/ontology/phenio.Makefile
+++ b/src/ontology/phenio.Makefile
@@ -32,7 +32,6 @@ $(BLMODEL):
 
 $(ONT)-full.owl: $(TMPDIR)/$(ONT)-full-unreasoned.owl | all_robot_plugins
 	$(ROBOT) merge --input $< \
-		relax \
 		merge --input $(BLMODEL) \
 		query --update $(BLQUERY) \
 		unmerge --input $(BLMODEL) \


### PR DESCRIPTION
Fixes #90 

As noted by @cmungall in #90, this relax step drops introduces a lot of redundant subclass of axioms. The alternative handling would be to continue processing it with reduce.

However, as we are continuing to push for our vision of modular ontologies, our goal in the community should be that all our ontologies are publised in their relaxed/reduced format so that application ontology building becomes, in essence, a plug and play exercise. Hence my preference to dropping relax here.

If need be we can relax individual sources in the `mirror` phase.