### PR TITLE
Update SSSOM/T-OWL rulesets.

### DIFF
--- a/src/ontology/config/mappings-to-uberon-bridge.rules
+++ b/src/ontology/config/mappings-to-uberon-bridge.rules
@@ -6,11 +6,10 @@ prefix CL:    <http://purl.obolibrary.org/obo/CL_>
 !(object==UBERON:* || object==CL:*) -> stop();
 
 # Ignore any mapping to/from an inexistent or obsolete class.
-predicate==* -> check_object_existence();
-predicate==* -> check_subject_existence();
+!exists(%{subject_id}) || !exists(%{object_id}) -> stop();
 
 # Ignore any mapping where the same foreign term is mapped to more than one UBERON/CL class.
 # !cardinality==*:1 -> stop();
 
 # Create the subclassOf axiom and annotate it with a subset of the mapping metadata
-predicate==semapv:crossSpeciesExactMatch -> create_axiom('%subject_id SubClassOf: %object_id', "direct:metadata");
+predicate==semapv:crossSpeciesExactMatch -> create_axiom('%subject_id SubClassOf: %object_id', /annots="metadata");

--- a/src/ontology/config/mappings-to-upheno-oba.rules
+++ b/src/ontology/config/mappings-to-upheno-oba.rules
@@ -2,13 +2,12 @@ prefix UPHENO:    <http://purl.obolibrary.org/obo/UPHENO_>
 prefix OBA:    <http://purl.obolibrary.org/obo/OBA_>
 prefix BFO:    <http://purl.obolibrary.org/obo/BFO_>
 
-# Make sure UBERON/CL classes, and only UBERON/CL classes, are on the object side
+# Make sure OBA classes, and only OBA classes, are on the object side
 subject==OBA:* -> invert();
 !object==OBA:* -> stop();
 
 # Ignore any mapping to/from an inexistent or obsolete class.
-predicate==* -> check_object_existence();
-predicate==* -> check_subject_existence();
+!exists(%{subject_id}) || !exists(%{object_id}) -> stop();
 
 # Create the subclassOf axiom and annotate it with a subset of the mapping metadata
-predicate==UPHENO:phenotypeToTrait -> create_axiom('%subject_id SubClassOf: BFO:0000051 some %object_id', "direct:metadata");
+predicate==UPHENO:phenotypeToTrait -> create_axiom('%subject_id SubClassOf: BFO:0000051 some %object_id', /annots="metadata");


### PR DESCRIPTION
The SSSOM/T-OWL rulesets used to inject mapping-derived axioms are using constructs (such as `check_subject_existence()`) that date from SSSOM-Java <= 0.9.0 and were deprecated in SSSOM-Java 1.0.0. Those constructs will no longer be supported in the upcoming SSSOM-Java 1.9.0.

This PR replaces those constructs by their modern equivalents in SSSOM-Java 1.0.0 and older.