### PR TITLE
Publish GitHub releases instead of drafts

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -1305,7 +1305,7 @@ GHVERSION=v$(VERSION)
 public_release:
 	@test $(GHVERSION)
 	ls -alt $(RELEASE_ASSETS_AFTER_RELEASE)
-	gh release create $(GHVERSION) --title "$(VERSION) Release" --draft $(RELEASE_ASSETS_AFTER_RELEASE) --generate-notes
+	gh release create $(GHVERSION) --title "$(VERSION) Release" --latest $(RELEASE_ASSETS_AFTER_RELEASE) --generate-notes
 
 # ----------------------------------------
 # General Validation


### PR DESCRIPTION
## Summary
- Swap `--draft` for `--latest` in the `public_release` target so Jenkins publishes real releases on GitHub rather than leaving them as drafts that need to be manually promoted.

## Test plan
- [ ] Next Jenkins run produces a published (non-draft) release marked as latest.