### PR TITLE
Use $(MIRRORDIR)/merged.owl as the upstream-versions ordering dep

### DIFF
--- a/src/ontology/phenio.Makefile
+++ b/src/ontology/phenio.Makefile
@@ -71,7 +71,13 @@ endif # MIR=true
 # this very TSV).
 
 UPSTREAM_VERSIONS_SPARQL = $(SPARQLDIR)/get-upstream-version.sparql
-UPSTREAM_VERSIONS_DEPS = $(IMPORT_FILES) $(filter-out $(COMPONENTSDIR)/upstream-versions.owl,$(OTHER_SRC))
+# We need each upstream's mirror-X .PHONY target to have run (so
+# $(TMPDIR)/mirror-*.owl files exist) before this recipe globs them.
+# `$(MIRRORDIR)/merged.owl` is the one parent-Makefile target that
+# transitively depends on every mirror via the `$(MIRRORDIR)/%.owl: mirror-%`
+# pattern rule, and (unlike $(IMPORT_FILES)) it doesn't cycle back through
+# $(IMPORTSEED) → $(PRESEED) → $(SRCMERGED).
+UPSTREAM_VERSIONS_DEPS = $(MIRRORDIR)/merged.owl
 
 .PHONY: upstream_versions
 upstream_versions: $(ONT)-upstream-versions.tsv $(COMPONENTSDIR)/upstream-versions.owl


### PR DESCRIPTION
Follow-up to #126. The order-only dep on \`\$(IMPORT_FILES)\` introduced there created a circular dependency that make detected and broke by silently dropping the \`\$(SRCMERGED) → components/upstream-versions.owl\` edge — leaving robot to fail with \`components/upstream-versions.owl (No such file or directory)\` on Jenkins.

## The cycle

\`\`\`
\$(SRCMERGED) ──→ components/upstream-versions.owl   (explicit prereq from #126)
              ──→ phenio-upstream-versions.tsv       (recipe dep)
              ──→ \$(IMPORT_FILES)                    (race-fix dep — the bad one)
              ──→ \$(IMPORTSEED)                      (parent Makefile line 387)
              ──→ \$(PRESEED)                         (parent Makefile line 372)
              ──→ \$(SRCMERGED)                       ← back to start
\`\`\`

Make's \`Circular tmp/merged-phenio-edit.ofn <- components/upstream-versions.owl dependency dropped.\` warning made it visible.

## Fix

Replace \`\$(IMPORT_FILES) + filtered \$(OTHER_SRC)\` with \`\$(MIRRORDIR)/merged.owl\` as the order-only ordering target. That's the one parent-Makefile target that transitively pulls every mirror via the \`\$(MIRRORDIR)/%.owl: mirror-%\` pattern rule, and (unlike imports) it doesn't trace back through \`\$(IMPORTSEED) → \$(PRESEED) → \$(SRCMERGED)\`.

## Validation

- Jenkins built green on this branch.
- Latest release [v2026-05-06](https://github.com/monarch-initiative/phenio/releases/tag/v2026-05-06) ships \`phenio-upstream-versions.tsv\` with 20 populated ontology rows (was: 0 in v2026-05-05, header-only).
- Released as published, not draft (PR #126's other fix held).

Squash-merge to land just this single commit on main.