### PR TITLE
Broaden upstream-versions manifest to component + mondo-transitive sources

### DIFF
--- a/src/ontology/phenio.Makefile
+++ b/src/ontology/phenio.Makefile
@@ -77,7 +77,7 @@ UPSTREAM_VERSIONS_SPARQL = $(SPARQLDIR)/get-upstream-version.sparql
 # transitively depends on every mirror via the `$(MIRRORDIR)/%.owl: mirror-%`
 # pattern rule, and (unlike $(IMPORT_FILES)) it doesn't cycle back through
 # $(IMPORTSEED) → $(PRESEED) → $(SRCMERGED).
-UPSTREAM_VERSIONS_DEPS = $(MIRRORDIR)/merged.owl
+UPSTREAM_VERSIONS_DEPS = $(MIRRORDIR)/merged.owl $(filter-out $(COMPONENTSDIR)/upstream-versions.owl,$(OTHER_SRC))
 
 .PHONY: upstream_versions
 upstream_versions: $(ONT)-upstream-versions.tsv $(COMPONENTSDIR)/upstream-versions.owl
@@ -85,9 +85,14 @@ upstream_versions: $(ONT)-upstream-versions.tsv $(COMPONENTSDIR)/upstream-versio
 .PHONY: $(ONT)-upstream-versions.tsv
 $(ONT)-upstream-versions.tsv: $(UPSTREAM_VERSIONS_SPARQL) | $(UPSTREAM_VERSIONS_DEPS) $(TMPDIR)
 	@printf "source\tontologyIRI\tversionIRI\tversionInfo\n" > $@
-	@for f in $(TMPDIR)/mirror-*.owl; do \
+	@for f in $(TMPDIR)/mirror-*.owl $(TMPDIR)/component-download-*.owl.owl; do \
 	  [ -s "$$f" ] || continue; \
-	  src=$$(basename "$$f" .owl); src=$${src#mirror-}; \
+	  base=$$(basename "$$f"); \
+	  case "$$base" in \
+	    mirror-*) src=$${base#mirror-}; src=$${src%.owl} ;; \
+	    component-download-*) src=$${base#component-download-}; src=$${src%.owl.owl} ;; \
+	    *) continue ;; \
+	  esac; \
 	  out=$(TMPDIR)/upstream-version-$$src.tsv; \
 	  $(ROBOT) query -i "$$f" -f tsv --query $< "$$out" >/dev/null 2>&1 || continue; \
 	  tail -n +2 "$$out" \
@@ -96,6 +101,28 @@ $(ONT)-upstream-versions.tsv: $(UPSTREAM_VERSIONS_SPARQL) | $(UPSTREAM_VERSIONS_
 	                                sub(/^"/,"",$$i); sub(/"$$/,"",$$i) } } \
 	        $$1!="" {print src,$$1,$$2,$$3}' >> $@; \
 	done
+	@# Pass through Mondo's own source-versions.tsv for transitive upstreams
+	@# (doid, ncit, omim, ordo, icd*) — keyed off the mondo versionIRI we
+	@# just captured, so the manifest reflects exactly the Mondo release
+	@# that was merged into this phenio. Skip rows whose source we already
+	@# have directly (direct ingest wins over transitive).
+	@mondo_ver=$$(awk -F'\t' '$$1=="mondo"{print $$3; exit}' $@); \
+	date=$$(printf '%s' "$$mondo_ver" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1); \
+	if [ -n "$$date" ]; then \
+	  url="https://github.com/monarch-initiative/mondo/releases/download/v$$date/source-versions.tsv"; \
+	  if curl -sLf --retry 3 --max-time 60 "$$url" -o $(TMPDIR)/mondo-source-versions.tsv; then \
+	    awk -F'\t' 'NR>1{print $$1}' $@ | sort -u > $(TMPDIR)/upstream-versions-have.txt; \
+	    tail -n +2 $(TMPDIR)/mondo-source-versions.tsv \
+	      | awk 'BEGIN{FS=OFS="\t"} \
+	          { for (i=1;i<=NF;i++) { sub(/^</,"",$$i); sub(/>$$/,"",$$i); \
+	                                  sub(/^"/,"",$$i); sub(/"$$/,"",$$i) } } \
+	          $$1!=""' \
+	      | awk -F'\t' 'NR==FNR{seen[$$1]=1; next} !seen[$$1]' \
+	          $(TMPDIR)/upstream-versions-have.txt - >> $@; \
+	  else \
+	    echo "WARN: could not fetch $$url; mondo-transitive sources will be absent" >&2; \
+	  fi; \
+	fi
 	@rows=$$(($$(wc -l < $@) - 1)); \
 	if [ $$rows -eq 0 ]; then \
 	  echo "ERROR: $@ produced zero data rows. Mirror files in $(TMPDIR) may not be ready." >&2; \

--- a/src/sparql/get-upstream-version.sparql
+++ b/src/sparql/get-upstream-version.sparql
@@ -1,7 +1,12 @@
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
-SELECT ?ontologyIRI ?versionIRI ?versionInfo WHERE {
+# Component-downloaded base files (e.g. go-base.owl, hp-base.owl) carry both
+# the upstream's owl:versionInfo (the real release date) and a second
+# owl:versionInfo added by ODK matching $(VERSION). Aggregate with MIN to
+# collapse to one row and prefer the older (upstream) value.
+SELECT ?ontologyIRI ?versionIRI (MIN(?vi) AS ?versionInfo) WHERE {
   ?ontologyIRI a owl:Ontology .
   OPTIONAL { ?ontologyIRI owl:versionIRI ?versionIRI . }
-  OPTIONAL { ?ontologyIRI owl:versionInfo ?versionInfo . }
+  OPTIONAL { ?ontologyIRI owl:versionInfo ?vi . }
 }
+GROUP BY ?ontologyIRI ?versionIRI


### PR DESCRIPTION
Closes #128

## Problem

`phenio-upstream-versions.tsv` (and the `upstream-versions.owl` component derived from it, consumed by kg-phenio's release-metadata) only listed 19 ontologies — the auxiliary ones imported via `tmp/mirror-*.owl`. The headliner ontologies merged into phenio (mondo, hp, go, uberon, cl, maxo, mp, oba, upheno, …) are downloaded into `tmp/component-download-*.owl.owl` instead, and were silently absent from the manifest. Mondo's own transitive sources (doid, ncit, omim, ordo, icd*) were also missing.

## Changes

`src/ontology/phenio.Makefile`:

- `UPSTREAM_VERSIONS_DEPS` now also order-only-depends on `$(filter-out $(COMPONENTSDIR)/upstream-versions.owl,$(OTHER_SRC))`, so component downloads exist before the TSV recipe runs.
- The TSV recipe's `for` loop globs both `tmp/mirror-*.owl` and `tmp/component-download-*.owl.owl`, with a `case` to derive the source name from either filename shape.
- After the per-file loop, the recipe parses the date from the `mondo` row's versionIRI and fetches `https://github.com/monarch-initiative/mondo/releases/download/v<DATE>/source-versions.tsv`. Rows whose `source` we don't already have are appended verbatim (direct ingest wins over transitive). On fetch failure the recipe warns and continues.

`src/sparql/get-upstream-version.sparql`:

- Aggregates with `MIN(?versionInfo)` and `GROUP BY ?ontologyIRI ?versionIRI`. Component-downloaded base files carry two `owl:versionInfo` literals — the upstream's real date and a second one matching `\$(VERSION)` added by ODK during the download/annotate step. `MIN` collapses them to one row and lexicographically prefers the older (upstream) value.

## Result

Manifest grows from 19 to 48 rows: 19 mirror + 22 component + 7 mondo-transitive. Verified locally by running the recipe in the \`obolibrary/odkfull:v1.6\` container against the existing \`tmp/\` artifacts.

Pre-existing quirks not addressed here: \`hgnc\` still has a blank-node ontologyIRI (its \`.nt\` source declares no \`owl:Ontology\` IRI); a few ontologies (xao, wbbt, ddanat) end up with the \`\$(VERSION)\` date in \`versionInfo\` because their downloads don't declare an upstream value — the real date is in the \`versionIRI\` column in those cases.