### PR TITLE
Populate in_taxon and description on HGNC gene imports

### DIFF
--- a/src/sparql/construct-hgnc.sparql
+++ b/src/sparql/construct-hgnc.sparql
@@ -7,19 +7,28 @@ CONSTRUCT {
   ?gene a owl:Class ;
      rdfs:subClassOf <http://purl.obolibrary.org/obo/SO_0000704> ;
      rdfs:label ?symbol ;
-     <http://purl.org/dc/terms/description> ?description . 
+     rdfs:subClassOf [
+        owl:onProperty <http://purl.obolibrary.org/obo/RO_0002162> ;
+        owl:someValuesFrom ?taxon ] ;
+     <http://purl.org/dc/terms/description> ?description .
 }
 WHERE {
  ?gene <https://w3id.org/biolink/vocab/category> <https://w3id.org/biolink/vocab/Gene> ;
      <https://w3id.org/biolink/vocab/in_taxon> ?taxon_xref ;
      <https://w3id.org/biolink/vocab/symbol> ?symbol .
 
+ # hgnc-ingest's nt has no dc:terms/description; full_name carries the long form.
+ # Prefer dc:description when present, fall back to biolink:full_name.
  OPTIONAL {
-  ?gene <http://purl.org/dc/terms/description> ?description .
+  ?gene <http://purl.org/dc/terms/description> ?dc_description .
  }
- 
+ OPTIONAL {
+  ?gene <https://w3id.org/biolink/vocab/full_name> ?full_name .
+ }
+ BIND(COALESCE(?dc_description, ?full_name) AS ?description)
+
+ BIND(IRI(REPLACE(str(?taxon_xref), "NCBITaxon:", "http://purl.obolibrary.org/obo/NCBITaxon_")) AS ?taxon)
+
  FILTER (!isBlank(?gene))
  FILTER ( regex(str(?gene), "^http://identifiers.org/hgnc/"))
 }
-
-


### PR DESCRIPTION
## Summary

`construct-hgnc.sparql` was binding `?taxon_xref` from the input but never using it in the CONSTRUCT clause, so HGNC gene nodes in phenio were emitted without any taxon information — making them unusable downstream as proper gene records for cross-species reasoning.

This update:

- **Adds the in_taxon assertion as an OWL existential restriction** (`rdfs:subClassOf [owl:onProperty RO:0002162 ; owl:someValuesFrom ?taxon]`), parallel to how `construct-ncbigene.sparql` already handles taxon.
- **Falls back from `dc:terms/description` to `biolink:full_name`** for the description, since hgnc-ingest's nt has no `dc:description` triple — only `full_name`. Result: descriptions like `"alpha-1-B glycoprotein"` now populate on HGNC nodes instead of being empty.

## Context

Part of the broader pipeline cleanup tracked in monarch-initiative/monarch-app#1307 — recovering MONDO-curated gene-disease associations through kg-phenio with full gene node properties. Specifically, this lets kg-phenio's gene-taxon materializer (forthcoming in a kg-phenio PR) populate `in_taxon`/`in_taxon_label` on HGNC nodes the same way it already can for NCBIGene nodes.
